### PR TITLE
Create missing ~/.fedora directory

### DIFF
--- a/Distribution/Fedora.hs
+++ b/Distribution/Fedora.hs
@@ -78,7 +78,10 @@ instance Read Dist where
 getProductsFile :: IO FilePath
 getProductsFile = do
   home <- getHomeDirectory
-  let file = home </> ".fedora/product-versions.json"
+  let dir = home </> ".fedora"
+  dirExists <- doesDirectoryExist dir
+  unless dirExists $ createDirectory dir
+  let file = dir </> "product-versions.json"
   recent <- do
     have <- doesFileExist file
     if have then do


### PR DESCRIPTION
This change ensure the ~/.fedora directory exists to prevent curl from failing with:
  curl: (23) Failed writing body (0 != 1283)
  fbrnch: ~/.fedora/product-versions.json: openBinaryFile: does not exist